### PR TITLE
Better exception handling and input processing

### DIFF
--- a/src/FsInteractiveService/App.config
+++ b/src/FsInteractiveService/App.config
@@ -10,5 +10,7 @@
         <bindingRedirect oldVersion="0.0.0.0-9999.9999.9999.9999" newVersion="4.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <!-- the following setting prevents the host from closing when an unhandled exception is thrown -->
+    <legacyUnhandledExceptionPolicy enabled="1" />
   </runtime>
 </configuration>

--- a/src/FsInteractiveService/Main.fs
+++ b/src/FsInteractiveService/Main.fs
@@ -56,15 +56,15 @@ type FsiSession =
 /// Extend the `fsi` object with `fsi.AddHtmlPrinter` 
 let addHtmlPrinter = """
   module FsInteractiveService = 
-    let htmlPrinters = ResizeArray<_>()
+    let mutable htmlPrinters = []
     let tryFormatHtml o = htmlPrinters |> Seq.tryPick (fun f -> f o)
 
   type Microsoft.FSharp.Compiler.Interactive.InteractiveSession with
     member x.AddHtmlPrinter<'T>(f:'T -> string) = 
-      FsInteractiveService.htmlPrinters.Add(fun (value:obj) ->
+      FsInteractiveService.htmlPrinters <- (fun (value:obj) ->
         match value with
         | :? 'T as value -> Some(f value)
-        | _ -> None)"""
+        | _ -> None) :: FsInteractiveService.htmlPrinters"""
 
 
 /// Start the F# interactive session with HAS_FSI_ADDHTMLPRINTER symbol defined

--- a/src/FsInteractiveService/Main.fs
+++ b/src/FsInteractiveService/Main.fs
@@ -86,9 +86,9 @@ let startSession () =
 
     // Load the `fsi` object from the right location of the `FSharp.Compiler.Interactive.Settings.dll`
     // assembly and add the `fsi.AddHtmlPrinter` extension method; then clean it from FSI output
+    let origLength = sbOut.Length
     let fsiLocation = Microsoft.FSharp.Compiler.Interactive.Settings.fsi.GetType().Assembly.Location
     fsiSession.EvalInteraction("#r @\"" + fsiLocation + "\"")
-    let origLength = sbOut.Length
     fsiSession.EvalInteraction(addHtmlPrinter)
     sbOut.Remove(origLength, sbOut.Length-origLength) |> ignore
 


### PR DESCRIPTION
A couple of minor tweaks:

 - Catch and report unhandled exceptions, fix fsi object, trim whitespace
 - Do not print FSI objects assembly location
 - Prefer the newest HTML printer

This is solving some of the issues I run into while working on FSI in Atom