### PR TITLE
IL merge Newtonsoft and minor output handling fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.2.1 - June 7, 2016
+ * ILRepack Newtonsoft.Json (to avoid loading it twice when used by users)
+
 #### 0.2.0 - May 31, 2016
  * Change AddHtmlPrinter to support FsLab Journal integration
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -11,6 +11,8 @@ group Build
   nuget FSharp.Compiler.Service
   nuget Newtonsoft.Json
   nuget FSharp.Core
+  nuget ILRepack
+
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 
 group Test

--- a/paket.lock
+++ b/paket.lock
@@ -13,6 +13,7 @@ NUGET
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
+    ILRepack (2.0.10)
     Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
@@ -21,13 +22,13 @@ NUGET
       Microsoft.Bcl.Build (>= 1.0.14)
     Newtonsoft.Json (8.0.3)
     Octokit (0.19)
-      Microsoft.Net.Http
+      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
     SourceLink.Fake (1.1)
     Suave (1.1.2)
       FSharp.Core (>= 3.1.2.5)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (db3139b0bf8a93047a68ca10f0135f1e94a10cae)
+    modules/Octokit/Octokit.fsx (60acb2f035cb39f2bd40a6c58a4de10d915da248)
       Octokit
 GROUP Test
 REDIRECTS: ON

--- a/src/FsInteractiveService.Shared/AssemblyInfo.fs
+++ b/src/FsInteractiveService.Shared/AssemblyInfo.fs
@@ -4,10 +4,10 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsInteractiveService.Shared")>]
 [<assembly: AssemblyProductAttribute("FsInteractiveService")>]
 [<assembly: AssemblyDescriptionAttribute("F# interactive service API exposed via a lightweight HTTP server")>]
-[<assembly: AssemblyVersionAttribute("0.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("0.2.0")>]
+[<assembly: AssemblyVersionAttribute("0.2.1")>]
+[<assembly: AssemblyFileVersionAttribute("0.2.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.2.0"
-    let [<Literal>] InformationalVersion = "0.2.0"
+    let [<Literal>] Version = "0.2.1"
+    let [<Literal>] InformationalVersion = "0.2.1"

--- a/src/FsInteractiveService.Shared/FsInteractiveService.Shared.fsproj
+++ b/src/FsInteractiveService.Shared/FsInteractiveService.Shared.fsproj
@@ -44,26 +44,6 @@
   </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="..\..\.paket\paket.targets" />
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0'))">
-      <ItemGroup>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\build\FSharp.Compiler.Service\lib\net40\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2'))">
-      <ItemGroup>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\build\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Extensions.fs" />
@@ -85,4 +65,24 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0'))">
+      <ItemGroup>
+        <Reference Include="FSharp.Compiler.Service">
+          <HintPath>..\..\packages\build\FSharp.Compiler.Service\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2'))">
+      <ItemGroup>
+        <Reference Include="FSharp.Compiler.Service">
+          <HintPath>..\..\packages\build\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/FsInteractiveService/AssemblyInfo.fs
+++ b/src/FsInteractiveService/AssemblyInfo.fs
@@ -4,10 +4,10 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsInteractiveService")>]
 [<assembly: AssemblyProductAttribute("FsInteractiveService")>]
 [<assembly: AssemblyDescriptionAttribute("F# interactive service API exposed via a lightweight HTTP server")>]
-[<assembly: AssemblyVersionAttribute("0.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("0.2.0")>]
+[<assembly: AssemblyVersionAttribute("0.2.1")>]
+[<assembly: AssemblyFileVersionAttribute("0.2.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.2.0"
-    let [<Literal>] InformationalVersion = "0.2.0"
+    let [<Literal>] Version = "0.2.1"
+    let [<Literal>] InformationalVersion = "0.2.1"

--- a/src/FsInteractiveService/Main.fs
+++ b/src/FsInteractiveService/Main.fs
@@ -252,10 +252,15 @@ let agent = MailboxProcessor.Start(fun inbox ->
             return! running None None session 
 
         // Read F# Interactive output 
-        | ReadOutput repl, _, _ ->
+        | ReadOutput repl, None, _ ->
             let output = session.Output.ToString()
             session.Output.Clear() |> ignore
             repl.Reply({ result = "output"; output = output; details = null })
+            return! running None thread session
+
+        // Do not read F# Interactive output when it's processed by background thread
+        | ReadOutput repl, Some _, _ ->
+            repl.Reply({ result = "output"; output = ""; details = null })
             return! running None thread session
 
         // Reset F# Interactive session

--- a/tests/FsInteractiveService.Tests/FsInteractiveService.Tests.fsproj
+++ b/tests/FsInteractiveService.Tests/FsInteractiveService.Tests.fsproj
@@ -60,6 +60,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FsInteractiveService">
+      <HintPath>..\..\bin\FsInteractiveService\FsInteractiveService.exe</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -73,13 +76,6 @@
   </Target>
   -->
   <Import Project="..\..\.paket\paket.targets" />
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FsInteractiveService\FsInteractiveService.fsproj">
-      <Name>FsInteractiveService</Name>
-      <Project>{020f5f39-566e-4604-8df0-3274671000af}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="..\..\packages\build\FSharp.Core\lib\net40\FSharp.Core.dll" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="..\..\packages\build\FSharp.Core\lib\net40\FSharp.Core.optdata" DestinationFolder="$(OutputPath)" />


### PR DESCRIPTION
If we do not IL merge `Newtonsoft.Json.dll`, then Vagabond (MBrace) breaks :-(

The issue was that `Newtonsoft.Json.dll` gets loaded from two different places (one that comes with FsInteractiveService and another that comes with FsLab, and Vagabond cannot resolve which one to use). Since this is `exe`, I think this is acceptable solution, though I'm not particularly happy with it.